### PR TITLE
fix: error validation field name is different from the json tag

### DIFF
--- a/src/helper/request-validator.go
+++ b/src/helper/request-validator.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/go-playground/validator/v10"
@@ -14,9 +15,10 @@ type errorValidation struct {
 func ValidateRequest(verr validator.ValidationErrors) errorValidation {
 	errs := make(map[string]string)
 	for _, f := range verr {
-		err := f.ActualTag()
-		err = translate(strings.ToLower(f.Field()), err, f.Param())
-		errs[strings.ToLower(f.Field())] = err
+		regex := regexp.MustCompile("(.)([A-Z])")
+		field := strings.ToLower(regex.ReplaceAllString(f.StructField(), "${1}_$2"))
+		err := translate(field, f.ActualTag(), f.Param())
+		errs[field] = err
 	}
 
 	return errorValidation{errs}


### PR DESCRIPTION
Before, the field name is taken from the `Field()` function and transformed into lowercase. But, this way will make it different from the JSON tag if it contains more than 1 word. So, I used the regexp to fix this problem.